### PR TITLE
remove depend

### DIFF
--- a/bit-docs.js
+++ b/bit-docs.js
@@ -17,12 +17,7 @@ module.exports = function(bitDocs){
     bitDocs.register("tags", tags);
     bitDocs.register("processor", processJavaScript);
 
-    var dependencies = {},
-        pack = require("./package.json");
-    dependencies[pack.name] = pack.version;
-
     bitDocs.register("html", {
-        dependencies: dependencies,
         templates: path.join(__dirname, "templates")
     });
 


### PR DESCRIPTION
Currently the [`package.json`](https://github.com/bit-docs/bit-docs-js/blob/master/package.json#L5) has a `main` that points to a non-existing file.

Would close #3